### PR TITLE
CI: upgrade GitHub actions to latest

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
         # Run on the latest minor release of Go 1.22:
         go-version: ^1.22
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
 
     - name: Ensure all files were formatted as per gofmt
       run: |

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
         # Run on the latest minor release of Go 1.22:
         go-version: ^1.22
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
 
     - name: Ensure all files were formatted as per gofmt
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
         # Run on the latest minor release of Go 1.22:
         go-version: ^1.22
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
 
     - name: Ensure all files were formatted as per gofmt
       run: |


### PR DESCRIPTION
* Move actions/checkout before actions/setup-go.
* Upgrade actions/checkout to v4.
* Upgrade actions/setup-go to v5.